### PR TITLE
Old link was 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Resources
 This component is a port of the Python lxml library, which is copyright Infrae
 and distributed under the BSD license.
 
-Current code is a port of https://github.com/SimonSapin/cssselect@v0.7.1
+Current code is a port of https://github.com/SimonSapin/cssselect/releases/tag/v0.7.1
 
 You can run the unit tests with the following command:
 


### PR DESCRIPTION
GitHub must have changed something because that link was no bueno. 
